### PR TITLE
[#7] 웹 어플리케이션 확장을 위한 세션id 공유하기 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,10 @@ dependencies {
     // db migration lib
     implementation 'org.flywaydb:flyway-core'
 
+    // 세션id를 분산저장하기 위한 redis와 spring session
+    implementation 'org.springframework.session:spring-session-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // lombok
     compileOnly 'org.projectlombok:lombok:1.18.22'
     annotationProcessor 'org.projectlombok:lombok:1.18.22'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,3 +12,13 @@ services:
       - "5432:5432"
     volumes:
       - ./data/postgres/:/var/lib/postgresql/data
+
+  redis:
+    image: redis:latest
+    restart: always
+    ports:
+      - "6379:6379"
+    volumes:
+      - ./data/redis/:/data
+      - ./data/redis/conf/redis.conf:/usr/local/conf/redis.conf
+    command: redis-server /usr/local/conf/redis.conf

--- a/src/main/java/com/lsh/talk/TalkAboutAnythingApplication.java
+++ b/src/main/java/com/lsh/talk/TalkAboutAnythingApplication.java
@@ -2,8 +2,10 @@ package com.lsh.talk;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 @SpringBootApplication
+@EnableRedisHttpSession
 public class TalkAboutAnythingApplication {
 
     public static void main(String[] args) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,17 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
+  # 세션id 분산저장을 위한 설정
+  redis:
+    host: localhost
+    port: 6379
+  session:
+    store-type: redis
+    timeout: 1800s
+    redis:
+      namespace: spring:session
+
+
 logging:
   level:
-    org.springframework.security: DEBUG
+    org.springframework.security: INFO


### PR DESCRIPTION
## 개요
redis 와 spring session 활용 
build.gradle: 분산저장을 위한 라이브러리 추가
application.yml: 세션id 저장 설정
docker-compose.yml: 분산저장을 위한 redis 환경 추가
TalkAboutAnythingApplication: redis에 세션id 저장 설정을 위한 자동 어노테이션 추가